### PR TITLE
Fix Broken Link In Documentation

### DIFF
--- a/doc/src/external_doc.md
+++ b/doc/src/external_doc.md
@@ -5,7 +5,7 @@ This page lists the external documentation that is used for the developement of 
 
 # Hardware technical references
 
-- [Intel® 64 and IA-32 Architectures Software Developes Manual](https://software.intel.com/content/dam/develop/public/us/en/documents/325462-sdm-vol-1-2abcd-3abcd.pdf)
+- [Intel® 64 and IA-32 Architectures Software Developes Manual](https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html)
 - [UEFI specification documents](https://uefi.org/uefi)
 - [PCI Local Bus Specification](https://www.ics.uci.edu/~harris/ics216/pci/PCI_22.pdf)
 


### PR DESCRIPTION
There is a broken link in the documentation. The old link does not work anymore, so I replaced it.

https://software.intel.com/content/dam/develop/public/us/en/documents/325462-sdm-vol-1-2abcd-3abcd.pdf --> https://www.intel.com/content/www/us/en/developer/articles/technical/intel-sdm.html

These broken link was found with [link-inspector](https://github.com/justindhillon/link-inspector). If you find this pr useful, give the project a star ⭐