### PR TITLE
Memory management and TTY fixes

### DIFF
--- a/kernel/src/arch/x86/paging.rs
+++ b/kernel/src/arch/x86/paging.rs
@@ -343,8 +343,7 @@ pub unsafe fn unmap(mut table: &mut Table, virtaddr: VirtAddr) {
 		let index = get_addr_element_index(virtaddr, level);
 		let entry = table[index].load(Relaxed);
 		tables[level] = Some((NonNull::from(table), index));
-		// If the entry does not exist or is PSE, stop here
-		if entry & FLAG_PRESENT == 0 || entry & FLAG_PAGE_SIZE != 0 {
+		if level == 0 || entry & FLAG_PRESENT == 0 || entry & FLAG_PAGE_SIZE != 0 {
 			break;
 		}
 		// Jump to next table

--- a/kernel/src/boot.rs
+++ b/kernel/src/boot.rs
@@ -79,7 +79,7 @@ static mut REMAP: Table = const {
 		// TODO use for loop when stabilized
 		let mut i = 0;
 		while i < 256 {
-			let addr = i * PAGE_SIZE * 1024;
+			let addr = i * PAGE_SIZE * 1024; // 4 MB entry
 			let ent = addr | FLAG_PAGE_SIZE | FLAG_WRITE | FLAG_PRESENT;
 			dir.0[i] = AtomicUsize::new(ent);
 			dir.0[i + 768] = AtomicUsize::new(ent);
@@ -94,7 +94,7 @@ static mut REMAP: Table = const {
 
 /// Directory use for the stage 1 of kernel remapping to higher memory under `x86_64`.
 ///
-/// This directory identity maps the first GiB of physical memory.
+/// This directory identity maps the first 512 GiB of physical memory.
 ///
 /// The static is marked as **mutable** because the CPU will set the dirty flag.
 #[unsafe(no_mangle)]
@@ -108,7 +108,7 @@ static mut REMAP_DIR: Table = const {
 	// TODO use for loop when stabilized
 	let mut i = 0;
 	while i < dir.0.len() {
-		let addr = i * PAGE_SIZE * 512;
+		let addr = i * PAGE_SIZE * 512 * 512; // 1 GB entry
 		dir.0[i] = AtomicUsize::new(addr | FLAG_PAGE_SIZE | FLAG_WRITE | FLAG_PRESENT);
 		i += 1;
 	}

--- a/kernel/src/tty/mod.rs
+++ b/kernel/src/tty/mod.rs
@@ -35,7 +35,7 @@ use crate::{
 	process::{Process, pid::Pid, signal::Signal},
 	sync::mutex::IntMutex,
 	tty::{
-		ansi::ANSIBuffer,
+		ansi::{ANSIBuffer, ESCAPE},
 		termios::{Termios, consts::*},
 	},
 };
@@ -338,7 +338,7 @@ impl TTYDisplay {
 		let mut i = 0;
 		while i < buf.len() {
 			let c = buf[i];
-			if c == ansi::ESCAPE_CHAR {
+			if c == ESCAPE {
 				let j = ansi::handle(self, &buf[i..buf.len()]);
 				if j > 0 {
 					i += j;


### PR DESCRIPTION
This PR does the following fixes:
- Avoid invalid free on memory unmapping in `VMem`
- Fix crash when booting in `x86_64` with more than 1GB
- TTY colors and clearing